### PR TITLE
[finishes #162184496]Link to the admin profile fixed

### DIFF
--- a/UI/admn_sign_in.html
+++ b/UI/admn_sign_in.html
@@ -23,7 +23,7 @@
       <label for="psw"><b>Password</b></label>
       <input type="password" placeholder="Enter Password" name="psw" required>
 
-      <button type="submit" onclick="Admn_profile.html">Login</button>
+      <button type="submit" onclick="location.href='Admn_profile.html'">Login</button>
       <label>
         <input type="checkbox" checked="checked" name="remember"> Remember me
       </label>


### PR DESCRIPTION
### What does this PR do?
Fixes the link to the Admin profile page
### Description of the task to be completed
Fix the link in the admin login page to allow admin to view the profile
### How can I manually test this?
Open the terminal 
Enter git clone https://github.com/wathigo/iReporter.git command
Go to the cloned repository and navigate to /iReporter/UI directory
Open admn_sign_in.html page using a browser
Click on the login button
### Relevant pivotal stories
#162184496